### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/azure-blob-connector-product/zip.xml
+++ b/azure-blob-connector-product/zip.xml
@@ -20,6 +20,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>README.md</include>
+                <include>README_DE.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/azure-blob-connector-product/zip.xml
+++ b/azure-blob-connector-product/zip.xml
@@ -19,8 +19,7 @@
       <directory>target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>README.md</include>
-                <include>README_DE.md</include>
+        <include>README*.md</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml